### PR TITLE
version and git-commit-id now get loaded by maven.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,18 @@
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>**/*.properties</exclude>
+                </excludes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <!--Filterung der properties Dateien, damit die Placeholder ersetzt werden-->
+                <filtering>true</filtering>
+                <includes>
+                    <include>**/*.properties</include>
+                </includes>
             </resource>
         </resources>
         <testResources>
@@ -76,6 +88,23 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>2.2.5</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <verbose>true</verbose>
+                    <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+                </configuration>
+            </plugin>
 
             <plugin>
                 <groupId>de.perdian.maven.plugins</groupId>

--- a/src/main/java/de/danielluedecke/zettelkasten/AboutBox.java
+++ b/src/main/java/de/danielluedecke/zettelkasten/AboutBox.java
@@ -34,6 +34,8 @@
 package de.danielluedecke.zettelkasten;
 
 import de.danielluedecke.zettelkasten.util.Constants;
+import de.danielluedecke.zettelkasten.util.Version;
+
 import java.awt.Desktop;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
@@ -61,7 +63,7 @@ public class AboutBox extends javax.swing.JDialog {
         initComponents();
         // set application icon
         setIconImage(Constants.zknicon.getImage());
-        setTitle("Zettelkasten "+Constants.BUILD_VERSION);
+        setTitle("Zettelkasten "+ Version.get().getVersionString());
         // these codelines add an escape-listener to the dialog. so, when the user
         // presses the escape-key, the same action is performed as if the user
         // presses the cancel button...

--- a/src/main/java/de/danielluedecke/zettelkasten/CErrorLog.java
+++ b/src/main/java/de/danielluedecke/zettelkasten/CErrorLog.java
@@ -33,10 +33,8 @@
 package de.danielluedecke.zettelkasten;
 
 import de.danielluedecke.zettelkasten.database.Settings;
-import de.danielluedecke.zettelkasten.util.ColorUtil;
-import de.danielluedecke.zettelkasten.util.Tools;
-import de.danielluedecke.zettelkasten.util.Constants;
-import de.danielluedecke.zettelkasten.util.FileOperationsUtil;
+import de.danielluedecke.zettelkasten.util.*;
+
 import java.awt.Desktop;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -107,7 +105,7 @@ public class CErrorLog extends javax.swing.JDialog {
                     Tools.flushSessionLog();
                     jTextArea2.setText("------------------------------"
                             + System.lineSeparator()
-                            + "Zettelkasten-Version: " + Constants.BUILD_VERSION
+                            + "Zettelkasten-Version: " + Version.get().getVersionString()
                             + System.lineSeparator()
                             + System.lineSeparator()
                             + Tools.getSystemInformation()
@@ -130,7 +128,7 @@ public class CErrorLog extends javax.swing.JDialog {
             // a separator line for a better overview
             sb.append("------------------------------").append(System.lineSeparator());
             // first, show programme-version
-            sb.append("Zettelkasten-Version: " + Constants.BUILD_VERSION).append(System.lineSeparator()).append(System.lineSeparator());
+            sb.append("Zettelkasten-Version: " + Version.get().getVersionString()).append(System.lineSeparator()).append(System.lineSeparator());
             // now show system-information (jre, os etc.)
             sb.append("System-Information:").append(System.lineSeparator()).append(Tools.getSystemInformation()).append(System.lineSeparator());
             // a separator line for a better overview

--- a/src/main/java/de/danielluedecke/zettelkasten/tasks/CheckForUpdateTask.java
+++ b/src/main/java/de/danielluedecke/zettelkasten/tasks/CheckForUpdateTask.java
@@ -4,6 +4,8 @@ package de.danielluedecke.zettelkasten.tasks;
 import de.danielluedecke.zettelkasten.ZettelkastenView;
 import de.danielluedecke.zettelkasten.database.Settings;
 import de.danielluedecke.zettelkasten.util.Constants;
+import de.danielluedecke.zettelkasten.util.Version;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -92,9 +94,9 @@ public class CheckForUpdateTask extends org.jdesktop.application.Task<Object, Vo
         // check whether we have a valid array with content
         if (updateversion != null && updateversion.length > 0) {
             // retrieve start-index of the build-number within the version-string.
-            int substringindex = Constants.BUILD_VERSION.indexOf("(Build") + 7;
+            int substringindex = Version.get().getVersionString().indexOf("(Build") + 7;
             // only copy buildinfo into string, other information of version-info are not needed
-            String curversion = Constants.BUILD_VERSION.substring(substringindex, substringindex + 8);
+            String curversion = Version.get().getVersionString().substring(substringindex, substringindex + 8);
             // store build number of update
             updateBuildNr = updateversion[0];
             // check whether there's a newer version online

--- a/src/main/java/de/danielluedecke/zettelkasten/util/Constants.java
+++ b/src/main/java/de/danielluedecke/zettelkasten/util/Constants.java
@@ -35,6 +35,9 @@ package de.danielluedecke.zettelkasten.util;
 import de.danielluedecke.zettelkasten.ZettelkastenView;
 import java.awt.Color;
 import java.awt.Dimension;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
 import java.util.logging.Logger;
 import javax.swing.ImageIcon;
 
@@ -47,10 +50,10 @@ import javax.swing.ImageIcon;
  */
 public class Constants {
 
-    /**
+    /*
      * This variable stores the current programme and build version number
      */
-    public static final String BUILD_VERSION = "3.2.8 (Build 20180603)";
+    // public static final String BUILD_VERSION = "3.2.8 (Build 20180603)";
     /**
      * This constants stores the website-address where the Zettelkasten can be
      * downloaded:<br><br>
@@ -1185,4 +1188,6 @@ public class Constants {
         "EEEE, d. MMM yyyy (HH:mm)",
         "EEEE, d. MMMM yyyy (HH:mm)",
         "yyyy-MM-dd HH:mm:ss"};
+
+
 }

--- a/src/main/java/de/danielluedecke/zettelkasten/util/Version.java
+++ b/src/main/java/de/danielluedecke/zettelkasten/util/Version.java
@@ -1,0 +1,37 @@
+package de.danielluedecke.zettelkasten.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+public class Version {
+
+
+    private static Version instance;
+    String version;
+    String build;
+    public static Version get() {
+        if (instance ==null)
+            instance = new Version();
+
+        return instance;
+    }
+
+    public String getVersionString() {
+        if (version == null) {
+            try (InputStream is = getClass().getResourceAsStream("/de/danielluedecke/zettelkasten/version.properties")) {
+                Properties versionProp = new Properties();
+                versionProp.load(is);
+                version = versionProp.getProperty("version");
+                build = versionProp.getProperty("git.commit.id.abbrev");
+            } catch (IOException e) {
+                Constants.zknlogger.severe("Could not load version.properties");
+            }
+        }
+        return version + " (Build " + build + ")";
+    }
+
+
+
+}

--- a/src/main/resources/de/danielluedecke/zettelkasten/version.properties
+++ b/src/main/resources/de/danielluedecke/zettelkasten/version.properties
@@ -1,0 +1,8 @@
+version=@project.version@
+git.branch=@git.branch@
+git.commit.id=@git.commit.id@
+git.commit.id.abbrev=@git.commit.id.abbrev@
+git.commit.time=@git.commit.time@
+git.closest.tag.name=@git.closest.tag.name@
+git.build.time=@git.build.time@
+git.build.version=@git.build.version@


### PR DESCRIPTION
Versiondetails werden jetzt von maven beim Bauen dynamisch geschrieben, damit die Versionsnummer nicht an zwei Stellen (Maven und Constants.java) gepflegt und die build commit id nicht manuell herausgesucht werden muss.