### PR TITLE
fix(awt.useSystemAAFontSetting): 

### DIFF
--- a/src/main/java/de/danielluedecke/zettelkasten/ZettelkastenApp.java
+++ b/src/main/java/de/danielluedecke/zettelkasten/ZettelkastenApp.java
@@ -76,7 +76,6 @@ public class ZettelkastenApp extends SingleFrameApplication {
      * @param args
      */
     public static void main(String[] args) {
-        System.setProperty("Dawt.useSystemAAFontSettings", "lcd");
         launch(ZettelkastenApp.class, args);
     }
 


### PR DESCRIPTION
the setting would be awt.useSystemAAFontSetting without "D" in front – but we should discuss whether we really need the feature #187.