### PR TITLE
Feature/#300 missing localized texts in file chooser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,4 @@ Temporary Items
 Zettelkasten.iml
 .classpath
 .project
+venv

--- a/pom.xml
+++ b/pom.xml
@@ -267,7 +267,7 @@
         <dependency>
             <groupId>com.formdev</groupId>
             <artifactId>flatlaf</artifactId>
-            <version>0.29</version>
+            <version>0.44</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.seaglasslookandfeel/seaglasslookandfeel -->
         <dependency>


### PR DESCRIPTION
resolves part of #300 
* missing localized texts in file chooser were a bug in the (old) FlatLaf version 0.29 that we used
