### PR TITLE
Update link to English website in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </p>
 
 
-The digital <i>Zettelkasten</i> (German for slip-box) is a program for knowledge management. It is inspired by the note-taking system of Niklas Luhmann. The official website can be found under [http://zettelkasten.danielluedecke.de](http://zettelkasten.danielluedecke.de)(German).
+The digital <i>Zettelkasten</i> (German for slip-box) is a program for knowledge management. It is inspired by the note-taking system of Niklas Luhmann. The official website can be found under [http://zettelkasten.danielluedecke.de](http://zettelkasten.danielluedecke.de/en/index.php).
 <br/>
 <br/>
 ![screenshot](http://zettelkasten.danielluedecke.de/img/gallery/zkn1.png)


### PR DESCRIPTION
Since  an English version of the website is available, it is not necessary to link to the German version anymore.