### PR TITLE
Improved newer backup dialog

### DIFF
--- a/src/main/java/de/danielluedecke/zettelkasten/ZettelkastenView.java
+++ b/src/main/java/de/danielluedecke/zettelkasten/ZettelkastenView.java
@@ -8965,7 +8965,15 @@ public class ZettelkastenView extends FrameView implements WindowListener, DropT
             if (modifiedOriginal < modifiedBackup) {
                 // ask the user whether he wants to load the original file,
                 // the newer backup-file or cancel the complete load-operation...
-                int option = JOptionPane.showConfirmDialog(getFrame(), getResourceMap().getString("newerBackupMsg"), getResourceMap().getString("newerBackupTitle"), JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
+                // create customized options
+                Object[] options = {getResourceMap().getString("newerBackupOptionsBackup"), getResourceMap().getString("newerBackupOptionsDatafile"), getResourceMap().getString("newerBackupOptionsCancel")};
+                int option = JOptionPane.showOptionDialog(getFrame(),
+                  getResourceMap().getString("newerBackupMsg"),
+                  getResourceMap().getString("newerBackupTitle"),
+                  JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE,
+                  null,
+                  options,
+                  options[0]);
                 // the user chose to cancel the operation, so return "null"
                 if (JOptionPane.CANCEL_OPTION == option || JOptionPane.CLOSED_OPTION == option /*User pressed cancel key*/) {
                     // clear filepath, so the data-file won't be accidently overwritten...
@@ -8974,7 +8982,7 @@ public class ZettelkastenView extends FrameView implements WindowListener, DropT
                     return false;
                 }
                 // here the user wants to open the backup-file instead of the older file...
-                if (JOptionPane.NO_OPTION == option) {
+                if (JOptionPane.YES_OPTION == option) {
                     try {
                         // in case the user already created a backup, we concatenate a trainling
                         // backup-counter-number to avoid overwriting existing backup-files

--- a/src/main/java/de/danielluedecke/zettelkasten/ZettelkastenView.java
+++ b/src/main/java/de/danielluedecke/zettelkasten/ZettelkastenView.java
@@ -8965,12 +8965,15 @@ public class ZettelkastenView extends FrameView implements WindowListener, DropT
             if (modifiedOriginal < modifiedBackup) {
                 // ask the user whether he wants to load the original file,
                 // the newer backup-file or cancel the complete load-operation...
-                // create customized options
-                Object[] options = {getResourceMap().getString("newerBackupOptionsBackup"), getResourceMap().getString("newerBackupOptionsDatafile"), getResourceMap().getString("newerBackupOptionsCancel")};
+                // first create customized options
+                Object[] options = {getResourceMap().getString("newerBackupOptionsBackup"), // YES_OPTION
+                  getResourceMap().getString("newerBackupOptionsDatafile"), // NO_OPTION
+                  getResourceMap().getString("newerBackupOptionsCancel")}; // CANCEL_OPTION
                 int option = JOptionPane.showOptionDialog(getFrame(),
                   getResourceMap().getString("newerBackupMsg"),
                   getResourceMap().getString("newerBackupTitle"),
-                  JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE,
+                  JOptionPane.YES_NO_CANCEL_OPTION,
+                  JOptionPane.PLAIN_MESSAGE,
                   null,
                   options,
                   options[0]);

--- a/src/main/resources/de/danielluedecke/zettelkasten/resources/ZettelkastenView.properties
+++ b/src/main/resources/de/danielluedecke/zettelkasten/resources/ZettelkastenView.properties
@@ -643,7 +643,7 @@ replaceSynonymsWithKeywordsTitle=Synonyme durch Originalschlagw\u00F6rter ersetz
 noNewKeywordsFoundMsg=<html>Der Zettel enth\u00E4lt bereits alle von Ihnen ausgew\u00E4hlten Schlagw\u00F6rter.<br><br>Es wurden keine neuen Schlagw\u00F6rter hinzugef\u00FCgt.</html>
 noNewKeywordsFoundTitle=Keine neuen Schlagw\u00F6rter
 
-newerBackupMsg=<html>F\u00FCr die zu \u00F6ffnende Datendatei existiert eine aktuellere Sicherungskopie.<br><br>M\u00F6chten Sie diese aktuellere Sicherungskopie oder die zuletzt von ihnen gespeicherte Datendatei öffnen?<br><br>Wenn Sie unsicher sind, wie Sie vorgehen sollen, w\u00E4hlen Sie <b>Sicherungskopie öffnen</b> aus.<br> Von Ihrer Datendatei wird dann automatisch eine Kopie angelegt, sodass diese Daten nicht verloren gehen.</html>
+newerBackupMsg=<html>F\u00FCr die zu \u00F6ffnende Datendatei existiert eine aktuellere Sicherungskopie.<br><br>M\u00F6chten Sie diese aktuellere Sicherungskopie oder die zuletzt von Ihnen gespeicherte Datendatei öffnen?<br><br>Wenn Sie unsicher sind, wie Sie vorgehen sollen, w\u00E4hlen Sie <b>Sicherungskopie öffnen</b> aus.<br> Von Ihrer Datendatei wird dann automatisch eine Kopie angelegt, sodass diese Daten nicht verloren gehen.</html>
 newerBackupTitle=Aktuellere Sicherungskopie vorhanden
 newerBackupOptionsCancel=Abbrechen
 newerBackupOptionsBackup=Sicherungskopie öffnen

--- a/src/main/resources/de/danielluedecke/zettelkasten/resources/ZettelkastenView.properties
+++ b/src/main/resources/de/danielluedecke/zettelkasten/resources/ZettelkastenView.properties
@@ -638,13 +638,17 @@ multipleOccurencesDesktop=Schreibtisch:
 multipleOccurencesLevel=Gliederungsebene:
 askForDeleteEntriesOnDesktop=Mindestens einer der zu entfernenden Zettel wird auch vom Schreibtisch verwendet. Wenn Sie dieses Fenster schlie\u00DFen, k\u00F6nnen Sie entscheiden, ob Sie die Eintr\u00E4ge dennoch entfernen m\u00F6chten oder nicht.
 
-replaceSynonymsWithKeywordsMsg=<html>Folgende Ihrer eingegebenen Schlagw\u00F6rter sind als Synonyme<br>von bereits vorhandenen Schlagw\u00F6rtern eingetragen:<br>%s<br><br>M\u00F6chten Sie diese Synonyme durch die vorhandenen<br>Index-Schlagw\u00F6rter ersetzen (empfohlen)?<br><br><b>Hinweis:</b> Mit <i>Abbrechen</i> f\u00FCgen Sie keine Schlagw\u00F6rter hinzu<br>und/oder brechen den aktuellen Vorgang ab..</html>
+replaceSynonymsWithKeywordsMsg=<html>Folgende Ihrer eingegebenen Schlagw\u00F6rter sind als Synonyme<br>von bereits vorhandenen Schlagw\u00F6rtern eingetragen:<br>%s<br><br>M\u00F6chten Sie diese Synonyme durch die vorhandenen<br>Index-Schlagw\u00F6rter ersetzen (empfohlen)?<br><br><b>Hinweis:</b> Mit <i>Abbrechen</i> f\u00FCgen Sie keine Schlagw\u00F6rter hinzu<br>und/oder brechen den aktuellen Vorgang ab.</html>
 replaceSynonymsWithKeywordsTitle=Synonyme durch Originalschlagw\u00F6rter ersetzen
 noNewKeywordsFoundMsg=<html>Der Zettel enth\u00E4lt bereits alle von Ihnen ausgew\u00E4hlten Schlagw\u00F6rter.<br><br>Es wurden keine neuen Schlagw\u00F6rter hinzugef\u00FCgt.</html>
 noNewKeywordsFoundTitle=Keine neuen Schlagw\u00F6rter
 
-newerBackupMsg=<html>F\u00FCr die zu \u00F6ffnende Datendatei existiert eine Sicherungskopie, die aktueller ist.<br><br>Das bedeutet, dass bei der letzten Verwendung des Zettelkastens vorgenommene<br>\u00C4nderungen beim Beenden nicht gesichert wurden.<br><br>M\u00F6chten Sie<br>- dennoch die Datendatei \u00F6ffnen (<b>Ja</b> ausw\u00E4hlen),<br>- die Sicherungskopie \u00F6ffnen (<b>Nein</b> ausw\u00E4hlen)<br>- oder mit <b>Abbrechen</b> den Vorgang ganz abbrechen, ohne eine Datei zu \u00F6ffnen?<br><br>Wenn Sie unsicher sind, wie Sie vorgehen sollen, w\u00E4hlen Sie <b>Nein</b> aus.<br>Von Ihrer Datendatei wird dann automatisch eine Kopie angelegt, sodass<br>diese Daten nicht verloren gehen.</html>
+newerBackupMsg=<html>F\u00FCr die zu \u00F6ffnende Datendatei existiert eine aktuellere Sicherungskopie.<br><br>M\u00F6chten Sie diese aktuellere Sicherungskopie oder die zuletzt von ihnen gespeicherte Datendatei öffnen?<br><br>Wenn Sie unsicher sind, wie Sie vorgehen sollen, w\u00E4hlen Sie <b>Sicherungskopie öffnen</b> aus.<br> Von Ihrer Datendatei wird dann automatisch eine Kopie angelegt, sodass diese Daten nicht verloren gehen.</html>
 newerBackupTitle=Aktuellere Sicherungskopie vorhanden
+newerBackupOptionsCancel=Abbrechen
+newerBackupOptionsBackup=Sicherungskopie öffnen
+newerBackupOptionsDatafile=Datendatei öffnen
+
 
 backupLoadedMsg=Ihre bisherige Datendatei wurde in %s umbenannt und befindet sich nach wie vor im Verzeichnis %sDie Sicherungskopie wird jetzt ge\u00F6ffnet und als Datendatei mit dem Namen %s verwendet.
 backupLoadedTitle=Sicherungskopie \u00F6ffnen


### PR DESCRIPTION
Changes for issue  Zettelkasten-Team/Zettelkasten#361.
Changed dialog text & dialog options.

Rectified encodings & added translations in commits 8e9f05920685144b160c0cbb72900ae93128fa4c & 058ca7abdf79ebc86433feaa2037f9387fb91454 from @RalfBarkow.