### PR TITLE
Fix logic to keep the collapsed nodes in the Note Sequences

### DIFF
--- a/src/main/java/de/danielluedecke/zettelkasten/DesktopFrame.java
+++ b/src/main/java/de/danielluedecke/zettelkasten/DesktopFrame.java
@@ -1623,7 +1623,7 @@ public class DesktopFrame extends javax.swing.JFrame implements WindowListener {
         int nr = getSelectedEntryNumber();
         // if we have a valid entry, get luhmann-numbers
         if (nr != -1) {
-            luhmann = dataObj.getLuhmannNumbers(nr);
+            luhmann = dataObj.getSubEntriesCsv(nr);
         }
         // enable actions that require a selected child-node (entty), that has luhmann-numbers
         setLuhmannNodeSelected(isNodeSelected() && !luhmann.isEmpty());
@@ -2139,7 +2139,7 @@ public class DesktopFrame extends javax.swing.JFrame implements WindowListener {
                     // now we know we have an entry. so get the entry number...
                     int nr = Integer.parseInt(e.getAttributeValue("id"));
                     // get the zettel title
-                    String title = TreeUtil.retrieveNodeTitle(dataObj, settingsObj.getShowDesktopEntryNumber(), String.valueOf(nr));
+                    String title = TreeUtil.getEntryDisplayText(dataObj, settingsObj.getShowDesktopEntryNumber(), new EntryID(nr));
                     // create a new node
                     node = new DefaultMutableTreeNode(new TreeUserObject(title, e.getAttributeValue("timestamp"), String.valueOf(nr)));
                     // and tell node not to have children
@@ -2837,7 +2837,7 @@ public class DesktopFrame extends javax.swing.JFrame implements WindowListener {
      */
     @Action(enabledProperty = "luhmannNodeSelected")
     public void addLuhmann() {
-        addEntries(dataObj.getLuhmannNumbers(getSelectedEntryNumber()));
+        addEntries(dataObj.getSubEntriesCsv(getSelectedEntryNumber()));
     }
 
     /**
@@ -2871,7 +2871,7 @@ public class DesktopFrame extends javax.swing.JFrame implements WindowListener {
      */
     private void fillLuhmannNumbers(int zettelpos) {
         // get the text from the luhmann-numbers
-        String lnr = dataObj.getLuhmannNumbers(zettelpos);
+        String lnr = dataObj.getSubEntriesCsv(zettelpos);
         // if we have any luhmann-numbers, go on...
         if (!lnr.isEmpty()) {
             String[] lnrs = lnr.split(",");

--- a/src/main/java/de/danielluedecke/zettelkasten/ZettelkastenView.java
+++ b/src/main/java/de/danielluedecke/zettelkasten/ZettelkastenView.java
@@ -7019,7 +7019,7 @@ public class ZettelkastenView extends FrameView implements WindowListener, DropT
 		for (int loopEntryId = 1; loopEntryId <= data.getCount(Daten.ZKNCOUNT); loopEntryId++) {
 			List<EntryID> subEntries = EntryIDUtils.csvToEntryIDList(data.getSubEntriesCsv(loopEntryId));
 			for (EntryID subEntry : subEntries) {
-				if (subEntry == activatedEntry) {
+				if (subEntry.equals(activatedEntry)) {
 					try {
 						isFollowerList.add(String.valueOf(loopEntryId));
 						// No need to look further at its siblings.

--- a/src/main/java/de/danielluedecke/zettelkasten/database/Daten.java
+++ b/src/main/java/de/danielluedecke/zettelkasten/database/Daten.java
@@ -7284,7 +7284,7 @@ public class Daten {
 	 * @return a string with the comma-separated luhmann-numbers, or an empty string
 	 *         if the entry has not luhmann-numbers.
 	 */
-	public String getLuhmannNumbers(int pos) {
+	public String getSubEntriesCsv(int pos) {
 		// get the entry
 		Element zettel = retrieveElement(zknFile, pos);
 		// if it exists...
@@ -7307,7 +7307,7 @@ public class Daten {
 	 */
 	public String[] getLuhmannNumbersAsString(int pos) {
 		// get manual links
-		String luh = getLuhmannNumbers(pos);
+		String luh = getSubEntriesCsv(pos);
 		// if no manual links there, quit...
 		if (luh.isEmpty()) {
 			return null;
@@ -7333,7 +7333,7 @@ public class Daten {
 	 */
 	public int[] getLuhmannNumbersAsInteger(int pos) {
 		// get manual links
-		String luh = getLuhmannNumbers(pos);
+		String luh = getSubEntriesCsv(pos);
 		// if no manual links there, quit...
 		if (luh.isEmpty()) {
 			return null;
@@ -7589,7 +7589,7 @@ public class Daten {
 			// go through complete data set
 			while (!innerLoopFound && cnt <= getCount(Daten.ZKNCOUNT)) {
 				// get the luhmann numbers of each entry
-				String[] lnrs = getLuhmannNumbers(cnt).split(",");
+				String[] lnrs = getSubEntriesCsv(cnt).split(",");
 				// now check each number for the occurrence of the current entry number
 				for (String l : lnrs) {
 					// when one of the luhmann numbers equals the current entry number...
@@ -7629,7 +7629,7 @@ public class Daten {
 	 */
 	private void retrieveAllLuhmannNumbers(int zettelpos) {
 		// get the text from the luhmann-numbers
-		String lnr = getLuhmannNumbers(zettelpos);
+		String lnr = getSubEntriesCsv(zettelpos);
 		// if we have any luhmann-numbers, go on...
 		if (!lnr.isEmpty()) {
 			// copy all values to an array
@@ -7731,7 +7731,7 @@ public class Daten {
 	 */
 	public boolean hasLuhmannNumbers(int zettelpos) {
 		// retrieve luhmann numbers
-		String lnr = getLuhmannNumbers(zettelpos);
+		String lnr = getSubEntriesCsv(zettelpos);
 		return (lnr != null && !lnr.isEmpty());
 	}
 

--- a/src/main/java/de/danielluedecke/zettelkasten/database/Daten.java
+++ b/src/main/java/de/danielluedecke/zettelkasten/database/Daten.java
@@ -5072,7 +5072,7 @@ public class Daten {
 	public boolean gotoEntry(int nr) {
 		// check whether it's out of bounds
 		// and leave method if it is...
-		if (!zettelExists(zettel) || isDeleted(nr)) {
+		if (!zettelExists(nr) || isDeleted(nr)) {
 			return false;
 		}
 		// else set the counter for the currently displayed entry

--- a/src/main/java/de/danielluedecke/zettelkasten/util/EntryIDUtils.java
+++ b/src/main/java/de/danielluedecke/zettelkasten/util/EntryIDUtils.java
@@ -1,0 +1,24 @@
+package de.danielluedecke.zettelkasten.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import de.danielluedecke.zettelkasten.EntryID;
+
+public class EntryIDUtils {
+	static public List<EntryID> csvToEntryIDList(String csv) {
+		if (csv.isEmpty()) {
+			return Collections.<EntryID>emptyList();
+		}
+		String[] entriesAsString = csv.split(",");
+		List<EntryID> retval = new ArrayList<EntryID>(entriesAsString.length);
+		for (String entryAsString : entriesAsString) {
+			if (entryAsString.isEmpty()) {
+				continue;
+			}
+			retval.add(new EntryID(entryAsString));
+		}
+		return retval;
+	}
+}

--- a/src/main/java/de/danielluedecke/zettelkasten/util/Tools.java
+++ b/src/main/java/de/danielluedecke/zettelkasten/util/Tools.java
@@ -1970,5 +1970,4 @@ public class Tools {
 				entry -> (Element) entry));
 
 	}
-
 }

--- a/src/main/java/de/danielluedecke/zettelkasten/util/TreeUtil.java
+++ b/src/main/java/de/danielluedecke/zettelkasten/util/TreeUtil.java
@@ -32,11 +32,13 @@
  */
 package de.danielluedecke.zettelkasten.util;
 
+import de.danielluedecke.zettelkasten.EntryID;
 import de.danielluedecke.zettelkasten.database.Daten;
 import de.danielluedecke.zettelkasten.util.classes.TreeUserObject;
-import java.util.ArrayList;
 import java.util.Enumeration;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.swing.JTree;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
@@ -50,261 +52,282 @@ import javax.swing.tree.TreePath;
  */
 public class TreeUtil {
 
-    private static final List<String> collapsedNodes = new ArrayList<>();
+	private static final Map<String, Boolean> collapsedNodes = new HashMap<String, Boolean>();
 
-    private static int expandLevel = -1;
+	private static int expandLevel = -1;
 
-    /**
-     * Sets the level to which sub branches a tree will be expanded.
-     *
-     * @param level the "depth" of the tree expansion.
-     */
-    public static void setExpandLevel(int level) {
-        expandLevel = level;
-    }
+	/**
+	 * Sets the level to which sub branches a tree will be expanded.
+	 *
+	 * @param level the "depth" of the tree expansion.
+	 */
+	public static void setExpandLevel(int level) {
+		expandLevel = level;
+	}
 
-    public static int getExpandLevel() {
-        return expandLevel;
-    }
+	public static int getExpandLevel() {
+		return expandLevel;
+	}
 
-    /**
-     * This method extracts a node's ID.
-     *
-     * @param node the node where we want to extract the ID
-     * @return the ID of the node's name (userobject) as string, or {@code null}
-     * if an error occured or nothing was found.
-     */
-    public static boolean nodeIsRoot(DefaultMutableTreeNode node) {
-        if (node != null) {
-            TreeUserObject userObject = (TreeUserObject) node.getUserObject();
-            return userObject.getId().equals(Constants.ROOT_ID_NAME);
-        }
-        return false;
-    }
+	/**
+	 * This method extracts a node's ID.
+	 *
+	 * @param node the node where we want to extract the ID
+	 * @return the ID of the node's name (userobject) as string, or {@code null} if
+	 *         an error occured or nothing was found.
+	 */
+	public static boolean nodeIsRoot(DefaultMutableTreeNode node) {
+		if (node != null) {
+			TreeUserObject userObject = (TreeUserObject) node.getUserObject();
+			return userObject.getId().equals(Constants.ROOT_ID_NAME);
+		}
+		return false;
+	}
 
-    /**
-     * This method returns the text of a node which is used in the DesktopFrame.
-     * This node usually has an id in its text. This method cuts off this id, so
-     * only the "cleaned" node-text wil be returned.
-     *
-     * @param node the node which text should be retrieved
-     * @return a "cleaned" node-text with the id truncated, or {@code null} if
-     * an error occured.
-     */
-    public static String getNodeText(DefaultMutableTreeNode node) {
-        String uebertext = null;
-        if (node != null) {
-            TreeUserObject userObject = (TreeUserObject) node.getUserObject();
-            uebertext = userObject.toString();
-        }
-        return uebertext;
-    }
+	/**
+	 * This method returns the text of a node which is used in the DesktopFrame.
+	 * This node usually has an id in its text. This method cuts off this id, so
+	 * only the "cleaned" node-text wil be returned.
+	 *
+	 * @param node the node which text should be retrieved
+	 * @return a "cleaned" node-text with the id truncated, or {@code null} if an
+	 *         error occured.
+	 */
+	public static String getNodeText(DefaultMutableTreeNode node) {
+		String uebertext = null;
+		if (node != null) {
+			TreeUserObject userObject = (TreeUserObject) node.getUserObject();
+			uebertext = userObject.toString();
+		}
+		return uebertext;
+	}
 
-    /**
-     * This method extracts a node's ID.
-     *
-     * @param node the node where we want to extract the ID
-     * @return the ID of the node's name (userobject) as string, or {@code null}
-     * if an error occured or nothing was found.
-     */
-    public static String getNodeID(DefaultMutableTreeNode node) {
-        if (node != null) {
-            TreeUserObject userObject = (TreeUserObject) node.getUserObject();
-            return userObject.getId();
-        }
-        return null;
-    }
+	/**
+	 * This method extracts a node's ID.
+	 *
+	 * @param node the node where we want to extract the ID
+	 * @return the ID of the node's name (userobject) as string, or {@code null} if
+	 *         an error occured or nothing was found.
+	 */
+	public static String getNodeID(DefaultMutableTreeNode node) {
+		if (node != null) {
+			TreeUserObject userObject = (TreeUserObject) node.getUserObject();
+			return userObject.getId();
+		}
+		return null;
+	}
 
-    /**
-     * This method extracts the timestamp-id of a node's name.
-     *
-     * @param node the node where we want to extract the timestamp-id
-     * @return the timestamp-id of the node's name (userobject) as string, or
-     * {@code null} if an error occured or nothing was found.
-     */
-    public static String getNodeTimestamp(DefaultMutableTreeNode node) {
-        if (node != null) {
-            TreeUserObject userObject = (TreeUserObject) node.getUserObject();
-            return userObject.getId();
-        }
-        return null;
-    }
+	/**
+	 * This method extracts the timestamp-id of a node's name.
+	 *
+	 * @param node the node where we want to extract the timestamp-id
+	 * @return the timestamp-id of the node's name (userobject) as string, or
+	 *         {@code null} if an error occured or nothing was found.
+	 */
+	public static String getNodeTimestamp(DefaultMutableTreeNode node) {
+		if (node != null) {
+			TreeUserObject userObject = (TreeUserObject) node.getUserObject();
+			return userObject.getId();
+		}
+		return null;
+	}
 
-    /**
-     * This method extracts an entry's number from a node's text (userobject)
-     * and returns it as integer-value
-     *
-     * @param node the node from which the entry-number should be extracted
-     * @return the entry-number, or -1 if an error occured.
-     */
-    public static int extractEntryNumberFromNode(DefaultMutableTreeNode node) {
-        TreeUserObject userObject = (TreeUserObject) node.getUserObject();
-        String entrynumber = userObject.getNr();
-        if (entrynumber != null && !entrynumber.isEmpty()) {
-            try {
-                return Integer.parseInt(entrynumber);
-            } catch (NumberFormatException e) {
-                return -1;
-            }
-        }
-        return -1;
-    }
+	/**
+	 * This method extracts an entry's number from a node's text (userobject) and
+	 * returns it as integer-value
+	 *
+	 * @param node the node from which the entry-number should be extracted
+	 * @return the entry-number, or -1 if an error occured.
+	 */
+	public static int extractEntryNumberFromNode(DefaultMutableTreeNode node) {
+		TreeUserObject userObject = (TreeUserObject) node.getUserObject();
+		String entrynumber = userObject.getNr();
+		if (entrynumber != null && !entrynumber.isEmpty()) {
+			try {
+				return Integer.parseInt(entrynumber);
+			} catch (NumberFormatException e) {
+				return -1;
+			}
+		}
+		return -1;
+	}
 
-    private static void expandAllTrees(TreePath parent, JTree tree) {
-        DefaultMutableTreeNode node = (DefaultMutableTreeNode) parent.getLastPathComponent();
-        if (node.getChildCount() >= 0) {
-            for (Enumeration e = node.children(); e.hasMoreElements();) {
-                DefaultMutableTreeNode n = (DefaultMutableTreeNode) e.nextElement();
-                TreePath path = parent.pathByAddingChild(n);
-                expandAllTrees(path, tree);
-            }
-        }
-        // retrieve treenode user object
-        TreeUserObject userObject = (TreeUserObject) node.getUserObject();
-        // check whether deepest level is reached.
-        if ((expandLevel != -1 && node.getLevel() < expandLevel) || -1 == expandLevel) {
-            // check whether treenode-id is in the list of collapsed items
-            if (userObject != null && collapsedNodes.contains(userObject.getId())) {
-                // if yes, collapse treenode
-                tree.collapsePath(parent);
-            } else {
-                // else expand it
-                tree.expandPath(parent);
-            }
-        } else {
-            tree.collapsePath(parent);
-        }
-    }
+	private static void expandAllTrees(TreePath root, JTree tree) {
+		DefaultMutableTreeNode node = (DefaultMutableTreeNode) root.getLastPathComponent();
+		// Handle the whole tree.
+		if (node.getChildCount() >= 0) {
+			for (Enumeration<TreeNode> e = node.children(); e.hasMoreElements();) {
+				DefaultMutableTreeNode n = (DefaultMutableTreeNode) e.nextElement();
+				TreePath path = root.pathByAddingChild(n);
+				expandAllTrees(path, tree);
+			}
+		}
 
-    /**
-     * If expand is true, expands all nodes in the tree. Otherwise, collapses
-     * all nodes in the tree.
-     *
-     * @param tree
-     */
-    public static void expandAllTrees(JTree tree) {
-        DefaultMutableTreeNode root = (DefaultMutableTreeNode) tree.getModel().getRoot();
-        expandAllTrees(new TreePath(root), tree);
-    }
+		// Handle root.
 
-    private static void expandAllTrees(TreePath parent, boolean expand, JTree tree) {
-        TreeNode node = (TreeNode) parent.getLastPathComponent();
-        if (node.getChildCount() >= 0) {
-            for (Enumeration e = node.children(); e.hasMoreElements();) {
-                TreeNode n = (TreeNode) e.nextElement();
-                TreePath path = parent.pathByAddingChild(n);
-                expandAllTrees(path, expand, tree);
-            }
-        }
-        if (expand) {
-            tree.expandPath(parent);
-        } else {
-            tree.collapsePath(parent);
-        }
-    }
+		TreeUserObject userObject1 = (TreeUserObject) node.getUserObject();
+		if (userObject1 != null && userObject1.getId().equals("3")) {
+			userObject1 = null;
+		}
+		if (userObject1 != null && userObject1.getId().equals("4")) {
+			userObject1 = null;
+		}
 
-    /**
-     * If expand is true, expands all nodes in the tree. Otherwise, collapses
-     * all nodes in the tree.
-     *
-     * @param expand
-     * @param tree
-     */
-    public static void expandAllTrees(boolean expand, JTree tree) {
-        TreeNode root = (TreeNode) tree.getModel().getRoot();
-        expandAllTrees(new TreePath(root), expand, tree);
-    }
+		// Respect collapsedNodes if it exists.
+		if (!collapsedNodes.isEmpty()) {
+			TreeUserObject userObject = (TreeUserObject) node.getUserObject();
+			if (userObject != null && collapsedNodes.get(userObject.getId())) {
+				tree.collapsePath(root);
+			} else {
+				tree.expandPath(root);
+			}
+		} else {
+			// Respect expandLevel.
+			if (expandLevel == -1 || node.getLevel() < expandLevel) {
+				tree.expandPath(root);
+			} else {
+				tree.collapsePath(root);
+			}
+		}
 
-    private static void retrieveCollapsedNodes(TreePath parent, JTree tree) {
-        DefaultMutableTreeNode node = (DefaultMutableTreeNode) parent.getLastPathComponent();
-        if (node.getChildCount() >= 0) {
-            for (Enumeration e = node.children(); e.hasMoreElements();) {
-                DefaultMutableTreeNode n = (DefaultMutableTreeNode) e.nextElement();
-                TreePath path = parent.pathByAddingChild(n);
-                retrieveCollapsedNodes(path, tree);
-            }
-        }
-        // retrieve treenode user object
-        TreeUserObject userObject = (TreeUserObject) node.getUserObject();
-        // check for valid value
-        if (userObject != null && userObject.isCollapsed()) {
-            // if treenode is collapsed, remember state
-            collapsedNodes.add(userObject.getId());
-        }
-    }
+		node = (DefaultMutableTreeNode) root.getLastPathComponent();
+		TreeUserObject userObject2 = (TreeUserObject) node.getUserObject();
+		if (userObject2 != null && userObject2.getId().equals("3")) {
+			userObject2 = null;
+		}
+	}
 
-    /**
-     * If expand is true, expands all nodes in the tree. Otherwise, collapses
-     * all nodes in the tree.
-     *
-     * @param tree
-     * @return
-     */
-    public static List<String> retrieveCollapsedNodes(JTree tree) {
-        // clear collapsed nodes
-        collapsedNodes.clear();
-        // if we have no tree, do nothing
-        if (null == tree) {
-            return null;
-        }
-        // get root
-        DefaultMutableTreeNode root = (DefaultMutableTreeNode) tree.getModel().getRoot();
-        // if we have no root, return
-        if (null == root) {
-            return null;
-        }
-        // else retrieve all collapsed nodes and save their ID's in a list
-        retrieveCollapsedNodes(new TreePath(root), tree);
-        return collapsedNodes;
-    }
+	/**
+	 * If expand is true, expands all nodes in the tree. Otherwise, collapses all
+	 * nodes in the tree.
+	 *
+	 * @param tree
+	 */
+	public static void expandAllTrees(JTree tree) {
+		DefaultMutableTreeNode root = (DefaultMutableTreeNode) tree.getModel().getRoot();
+		expandAllTrees(new TreePath(root), tree);
+	}
 
-    public static String retrieveNodeTitle(Daten data, boolean showNumber, String nr) {
-        StringBuilder sb = new StringBuilder("");
-        String zettelTitle = data.getZettelTitle(Integer.parseInt(nr));
-        if (showNumber || zettelTitle.isEmpty()) {
-            sb.append(nr);
-            if (!zettelTitle.isEmpty()) {
-                sb.append(": ");
-            }
-        }
-        if (!zettelTitle.isEmpty()) {
-            sb.append(zettelTitle);
-        }
-        return sb.toString();
-    }
+	private static void expandAllTrees(TreePath parent, boolean expand, JTree tree) {
+		TreeNode node = (TreeNode) parent.getLastPathComponent();
+		if (node.getChildCount() >= 0) {
+			for (Enumeration<? extends TreeNode> e = node.children(); e.hasMoreElements();) {
+				TreeNode n = e.nextElement();
+				TreePath path = parent.pathByAddingChild(n);
+				expandAllTrees(path, expand, tree);
+			}
+		}
+		if (expand) {
+			tree.expandPath(parent);
+		} else {
+			tree.collapsePath(parent);
+		}
+	}
 
-    /**
-     * Clears the array that saves all currently collapsed nodes from the
-     * jLuhmannTree, so the tree cabn be fully expanded.
-     */
-    public static void resetCollapsedNodes() {
-        // clear collapsed nodes
-        collapsedNodes.clear();
-    }
+	/**
+	 * If expand is true, expands all nodes in the tree. Otherwise, collapses all
+	 * nodes in the tree.
+	 *
+	 * @param expand
+	 * @param tree
+	 */
+	public static void expandAllTrees(boolean expand, JTree tree) {
+		TreeNode root = (TreeNode) tree.getModel().getRoot();
+		expandAllTrees(new TreePath(root), expand, tree);
+	}
 
-    /**
-     * This method selects the first entry in a jTree that start with the text
-     * that is entered in the filter-textfield.
-     *
-     * @param tree the jTree where the item should be selected
-     * @param textfield the related filtertextfield that contains the user-input
-     */
-    public static void selectByTyping(javax.swing.JTree tree, javax.swing.JTextField textfield) {
-        DefaultTreeModel dtm = (DefaultTreeModel) tree.getModel();
-        MutableTreeNode root = (MutableTreeNode) dtm.getRoot();
-        String text = textfield.getText().toLowerCase();
-        if (root != null && !text.isEmpty()) {
-            for (int cnt = 0; cnt < dtm.getChildCount(root); cnt++) {
-                MutableTreeNode child = (MutableTreeNode) dtm.getChild(root, cnt);
-                String childtext = child.toString().toLowerCase();
-                if (childtext.startsWith(text)) {
-                    TreePath tp = new TreePath(root);
-                    tp = tp.pathByAddingChild(child);
-                    tree.setSelectionPath(tp);
-                    tree.scrollPathToVisible(tp);
-                    return;
-                }
-            }
-        }
-    }
+	private static void saveCollapsedNodes(TreePath nodePath, JTree tree) {
+		DefaultMutableTreeNode node = (DefaultMutableTreeNode) nodePath.getLastPathComponent();
+		// Save the whole tree.
+		if (node.getChildCount() >= 0) {
+			for (Enumeration<TreeNode> e = node.children(); e.hasMoreElements();) {
+				DefaultMutableTreeNode n = (DefaultMutableTreeNode) e.nextElement();
+				TreePath path = nodePath.pathByAddingChild(n);
+				saveCollapsedNodes(path, tree);
+			}
+		}
+
+		TreeUserObject userObject1 = (TreeUserObject) node.getUserObject();
+		if (userObject1 != null && userObject1.getId().equals("3")) {
+			userObject1 = null;
+		}
+		if (userObject1 != null && userObject1.getId().equals("4")) {
+			userObject1 = null;
+		}
+
+		// Save the current node.
+		TreeUserObject userObject = (TreeUserObject) node.getUserObject();
+		if (userObject != null) {
+			collapsedNodes.put(userObject.getId(), userObject.isCollapsed());
+		}
+	}
+
+	/**
+	 * If expand is true, expands all nodes in the tree. Otherwise, collapses all
+	 * nodes in the tree.
+	 *
+	 * @param tree
+	 * @return
+	 */
+	public static void saveCollapsedNodes(JTree tree) {
+		collapsedNodes.clear();
+		if (tree == null) {
+			return;
+		}
+		DefaultMutableTreeNode root = (DefaultMutableTreeNode) tree.getModel().getRoot();
+		if (root == null) {
+			return;
+		}
+
+		saveCollapsedNodes(new TreePath(root), tree);
+	}
+
+	public static String getEntryDisplayText(Daten data, boolean showNumber, EntryID entry) {
+		StringBuilder sb = new StringBuilder("");
+		String entryTitle = data.getZettelTitle(entry.asInt());
+
+		// If title is empty, we use its number.
+		if (showNumber || entryTitle.isEmpty()) {
+			sb.append(entry.asString());
+		}
+		if (!entryTitle.isEmpty()) {
+			sb.append(": ");
+			sb.append(entryTitle);
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * Clears the array that saves all currently collapsed nodes from the
+	 * jLuhmannTree, so the tree can be fully expanded.
+	 */
+	public static void resetCollapsedNodes() {
+		collapsedNodes.clear();
+	}
+
+	/**
+	 * This method selects the first entry in a jTree that start with the text that
+	 * is entered in the filter-textfield.
+	 *
+	 * @param tree      the jTree where the item should be selected
+	 * @param textfield the related filtertextfield that contains the user-input
+	 */
+	public static void selectByTyping(javax.swing.JTree tree, javax.swing.JTextField textfield) {
+		DefaultTreeModel dtm = (DefaultTreeModel) tree.getModel();
+		MutableTreeNode root = (MutableTreeNode) dtm.getRoot();
+		String text = textfield.getText().toLowerCase();
+		if (root != null && !text.isEmpty()) {
+			for (int cnt = 0; cnt < dtm.getChildCount(root); cnt++) {
+				MutableTreeNode child = (MutableTreeNode) dtm.getChild(root, cnt);
+				String childtext = child.toString().toLowerCase();
+				if (childtext.startsWith(text)) {
+					TreePath tp = new TreePath(root);
+					tp = tp.pathByAddingChild(child);
+					tree.setSelectionPath(tp);
+					tree.scrollPathToVisible(tp);
+					return;
+				}
+			}
+		}
+	}
 }

--- a/src/main/java/de/danielluedecke/zettelkasten/util/TreeUtil.java
+++ b/src/main/java/de/danielluedecke/zettelkasten/util/TreeUtil.java
@@ -165,14 +165,6 @@ public class TreeUtil {
 
 		// Handle root.
 
-		TreeUserObject userObject1 = (TreeUserObject) node.getUserObject();
-		if (userObject1 != null && userObject1.getId().equals("3")) {
-			userObject1 = null;
-		}
-		if (userObject1 != null && userObject1.getId().equals("4")) {
-			userObject1 = null;
-		}
-
 		// Respect collapsedNodes if it exists.
 		if (!collapsedNodes.isEmpty()) {
 			TreeUserObject userObject = (TreeUserObject) node.getUserObject();
@@ -188,12 +180,6 @@ public class TreeUtil {
 			} else {
 				tree.collapsePath(root);
 			}
-		}
-
-		node = (DefaultMutableTreeNode) root.getLastPathComponent();
-		TreeUserObject userObject2 = (TreeUserObject) node.getUserObject();
-		if (userObject2 != null && userObject2.getId().equals("3")) {
-			userObject2 = null;
 		}
 	}
 

--- a/src/test/java/de/danielluedecke/zettelkasten/database/DatenTest.java
+++ b/src/test/java/de/danielluedecke/zettelkasten/database/DatenTest.java
@@ -59,31 +59,31 @@ public class DatenTest {
 		Daten daten = new Daten(document);
 
 		daten.deleteLuhmannNumber(new EntryID(1), new EntryID(10));
-		assertEquals("4,61,161,1771,3622", daten.getLuhmannNumbers(1));
+		assertEquals("4,61,161,1771,3622", daten.getSubEntriesCsv(1));
 
 		daten.deleteLuhmannNumber(new EntryID(1), new EntryID(4));
-		assertEquals("61,161,1771,3622", daten.getLuhmannNumbers(1));
+		assertEquals("61,161,1771,3622", daten.getSubEntriesCsv(1));
 	}
 
 	@Test
 	void testAddSubEntryToEntryAtPosition_PositionZero() {
 		Daten daten = new Daten(document);
 		assertTrue(daten.addSubEntryToEntryAtPosition(new EntryID(2), new EntryID(3), 0));
-		assertEquals("3,1", daten.getLuhmannNumbers(2));
+		assertEquals("3,1", daten.getSubEntriesCsv(2));
 	}
 
 	@Test
 	void testAddSubEntryToEntryAtPosition_PositionMinusOne() {
 		Daten daten = new Daten(document);
 		assertTrue(daten.addSubEntryToEntryAtPosition(new EntryID(2), new EntryID(3), -1));
-		assertEquals("1,3", daten.getLuhmannNumbers(2));
+		assertEquals("1,3", daten.getSubEntriesCsv(2));
 	}
 
 	@Test
 	void testAddSubEntryToEntryAtPosition_PositionOne() {
 		Daten daten = new Daten(document);
 		assertTrue(daten.addSubEntryToEntryAtPosition(new EntryID(2), new EntryID(3), 1));
-		assertEquals("1,3", daten.getLuhmannNumbers(2));
+		assertEquals("1,3", daten.getSubEntriesCsv(2));
 	}
 
 	@Test
@@ -102,6 +102,6 @@ public class DatenTest {
 	void testAddSubEntryToEntryAfterSibling() {
 		Daten daten = new Daten(document);
 		assertTrue(daten.addSubEntryToEntryAfterSibling(new EntryID(2), new EntryID(3), new EntryID(1)));
-		assertEquals("1,3", daten.getLuhmannNumbers(2));
+		assertEquals("1,3", daten.getSubEntriesCsv(2));
 	}
 }

--- a/src/test/java/de/danielluedecke/zettelkasten/util/EntryIDUtilsTest.java
+++ b/src/test/java/de/danielluedecke/zettelkasten/util/EntryIDUtilsTest.java
@@ -1,0 +1,29 @@
+package de.danielluedecke.zettelkasten.util;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import de.danielluedecke.zettelkasten.EntryID;
+
+public class EntryIDUtilsTest {
+	@Test
+	void testCsvToEntryIDList() {
+		// Expected normal cases.
+		Assert.assertEquals(Arrays.asList(), EntryIDUtils.csvToEntryIDList(""));
+		Assert.assertEquals(Arrays.asList(new EntryID(1), new EntryID(2)), EntryIDUtils.csvToEntryIDList("1,2"));
+		
+		// Treated cases.
+		Assert.assertEquals(Arrays.asList(new EntryID(1)), EntryIDUtils.csvToEntryIDList(",1"));
+		Assert.assertEquals(Arrays.asList(new EntryID(1), new EntryID(2)), EntryIDUtils.csvToEntryIDList("1,2,"));
+		
+		// Exception cases
+		Assert.assertThrows(NumberFormatException.class, () -> {
+			EntryIDUtils.csvToEntryIDList("noncsv,");
+	    });
+		Assert.assertThrows(NumberFormatException.class, () -> {
+			EntryIDUtils.csvToEntryIDList("1,2,nonnumber");
+	    });
+	}
+}


### PR DESCRIPTION
Now we can move entries around without loosing the collapsed/expanded
state of the tree.